### PR TITLE
ci: auto sync original repository

### DIFF
--- a/.github/workflows/auto-sync-fork-release.yml
+++ b/.github/workflows/auto-sync-fork-release.yml
@@ -1,0 +1,22 @@
+name: Merge upstream branches
+on:
+  schedule:
+     # Everyday at 0201
+    - cron:  '1 2 * * *'
+  # Allows manual workflow run (must in default branch to work)
+  workflow_dispatch:
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync and merge upstream repository with your current repository
+        uses: dabreadman/sync-upstream-repo@v1.3.0
+        with:
+          # URL of gitHub public upstream repo
+          upstream_repo: "https://github.com/ProjectBorealis/UEGitPlugin.git"
+          # Branch to merge from upstream (defaults to downstream branch)
+          UPSTREAM_BRANCH: release
+          # Branch to merge into downstream is equal
+          # GitHub Bot token
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Creating new default branch: main 
Will be used to host github action to update the release branch, the default one used on the forked repo.